### PR TITLE
Fix dorion-fullscreen bugs

### DIFF
--- a/plugins/dorion-fullscreen/index.tsx
+++ b/plugins/dorion-fullscreen/index.tsx
@@ -12,11 +12,11 @@ const {
 
 const toggleFullscreen = async (payload) => {
   const isFullscreen = payload?.properties?.video_layout === 'full-screen'
-  appWindow?.setFullscreen(isFullscreen)
+  appWindow?.setFullscreen(!isFullscreen)
 }
 
-FluxDispatcher.subscribe('TRACK', toggleFullscreen)
+FluxDispatcher.subscribe('WINDOW_FULLSCREEN_CHANGE', toggleFullscreen)
 
 export const onUnload = () => {
-  FluxDispatcher.unsubscribe('TRACK', toggleFullscreen)
+  FluxDispatcher.unsubscribe('WINDOW_FULLSCREEN_CHANGE', toggleFullscreen)
 }


### PR DESCRIPTION
This fixes https://github.com/SpikeHD/shelter-plugins/issues/12 by subscribing to the correct flux event, i.e. `'WINDOW_FULLSCREEN_CHANGE'` instead of `'TRACK'`.

The issue was that `'TRACK'` fires multiple times when clicking on any user's "video" stream in the voice channel view, whereas fullscreen should only be concerned with the full-screen button, which fires the `'WINDOW_FULLSCREEN_CHANGE'` event when pressed, consistently.

Also added a `!` in the call to `setFullscreen` (so that if it is not fullscreen it calls for fullscreen and vice versa)