### PR TITLE
[shelteRPC] Proper app lookup

### DIFF
--- a/plugins/shelteRPC/index.tsx
+++ b/plugins/shelteRPC/index.tsx
@@ -29,7 +29,7 @@ const apps: Record<string, { name: string } | string> = {}
 store.currentlyPlaying = ''
 
 async function lookupApp(appId: string): Promise<string> {
-  return (await shelter.http.get(`/oauth2/applications/${appId}/rpc`)).body
+  return (await shelter.http.get(`/oauth2/applications/${appId}/rpc`))?.body || 'Unknown'
 }
 
 export const generateAssetId = async (appId: string, asset: string) => {

--- a/plugins/shelteRPC/index.tsx
+++ b/plugins/shelteRPC/index.tsx
@@ -10,8 +10,7 @@ interface AssetCache {
 
 const {
   flux: {
-    dispatcher: FluxDispatcher,
-    stores: { GameStore },
+    dispatcher: FluxDispatcher
   },
   settings: { registerSection },
   ui: { showToast },
@@ -29,8 +28,8 @@ const apps: Record<string, { name: string } | string> = {}
 // when we load, set current game as nothing
 store.currentlyPlaying = ''
 
-async function lookupApp(name: string): Promise<string> {
-  return GameStore.getGameByName(name)?.name || 'Unknown'
+async function lookupApp(appId: string): Promise<string> {
+  return (await shelter.http.get(`/oauth2/applications/${appId}/rpc`)).body
 }
 
 export const generateAssetId = async (appId: string, asset: string) => {
@@ -67,7 +66,7 @@ async function handleMessage(e: MessageEvent<string>) {
 
   if (data.activity) {
     const appId = data.activity.application_id
-    apps[appId] ||= await lookupApp(data.activity.name)
+    apps[appId] ||= await lookupApp(appId)
 
     const app = apps[appId]
     if (typeof app !== 'string') {

--- a/plugins/shelteRPC/index.tsx
+++ b/plugins/shelteRPC/index.tsx
@@ -29,7 +29,7 @@ const apps: Record<string, { name: string } | string> = {}
 store.currentlyPlaying = ''
 
 async function lookupApp(appId: string): Promise<string> {
-  return (await shelter.http.get(`/oauth2/applications/${appId}/rpc`))?.body || 'Unknown'
+  return (await http.get(`/oauth2/applications/${appId}/rpc`))?.body || 'Unknown'
 }
 
 export const generateAssetId = async (appId: string, asset: string) => {


### PR DESCRIPTION
Before, some apps (or all?) weren't properly looked up, leading to a missing "name" parameter, failing the display of an activity.
The updated lookup is indirectly done the same way as in arRPC's example [bridge script](https://github.com/OpenAsar/arrpc/blob/main/examples/bridge_mod.js) and Vencord's arRPC plugin (which display all activities properly).
I did not test this with rsRPC or with many activities. 