### PR TITLE
shelteRPC: Add websocket connection address setting

### DIFF
--- a/plugins/shelteRPC/index.tsx
+++ b/plugins/shelteRPC/index.tsx
@@ -161,7 +161,7 @@ export const onLoad = async () => {
 
   const connected = await retry(
     async (curTry) => {
-      ws = new WebSocket('ws://127.0.0.1:1337')
+      ws = new WebSocket('ws://' + (store.connAddr || '127.0.0.1:1337'))
       ws.onmessage = handleMessage
       ws.onerror = (e) => { throw e }
 
@@ -241,6 +241,19 @@ export const settings = () => (
         value={store.retryWait ?? 3000}
         onInput={(v) => store.retryWait = v}
         type="number"
+      />
+    </div>
+
+    <div class={classes.container}>
+      <Text>Connection Address</Text>
+      <TextBox
+        value={store.connAddr ?? '127.0.0.1:1337'}
+        onInput={(v) => {
+          store.connAddr = v
+          // Maybe debounce this as onInput is called on every keystroke
+          onLoad()
+        }}
+        type="text"
       />
     </div>
   </>


### PR DESCRIPTION
Port 1337 may be occupied by other software, and while arRPC allows changing its bridge port with ARRPC_BRIDGE_PORT env variable, there is no way to change the port in shelteRPC.

Or the RPC server might be running on one computer on the network, while you want to listen for the RPC messages from another computer.

This PR adds a setting to change the server's WebSocket address to make the above possible.