### PR TITLE
fix: title bar wait stuck at app

### DIFF
--- a/plugins/dorion-titlebar/index.tsx
+++ b/plugins/dorion-titlebar/index.tsx
@@ -1,7 +1,7 @@
 import { Controls, Titlebar } from './Titlebar.jsx'
 import { setMaximizeIcon } from './actions.js'
 import { css, classes } from './index.scss'
-import { waitForElm } from './waitElm.js'
+import { disobserve, waitForElm } from './waitElm.js'
 
 const {
   ui: { injectCss },
@@ -38,11 +38,12 @@ const injectControls = async () => {
   insertTitleBar(document.body)
   // cancel old observer to inject new controls
   const discordPanel = await waitDiscordPanel(elm => insertTitleBar(elm))
-  const discordBar = await waitForElm(['div[data-layer=base]', '>div[class*=container]', '>div[class*=base]', ['>div[class*=bar_]', '>div[class*=-bar]']], {root:discordPanel})
+  const discordBar = await waitForElm(['div[data-layer=base]>div[class*=container]', '>div[class*=base]', ['>div[class*=bar_]', '>div[class*=-bar]']], {root:discordPanel})
   waitForElm('>div[class*=trailing]', {callbackFn: elm => {
     insertStandaloneControl(elm)
-    const discordBarTitle = discordBar.querySelector('div[class*=title]')
-    if (discordBarTitle) discordBarTitle.setAttribute('data-tauri-drag-region', 'true')
+  }, root: discordBar})
+  waitForElm('>div[class*=title]', {callbackFn: elm => {
+    elm.setAttribute('data-tauri-drag-region', 'true')
   }, root: discordBar})
 }
 
@@ -91,6 +92,7 @@ export const onLoad = async () => {
 }
 
 export const onUnload = () => {
+  disobserve()
   dispatcher.unsubscribe('LAYER_PUSH', handleFullTitlebar)
   dispatcher.unsubscribe('LAYER_POP', handleControlsOnly)
   dispatcher.unsubscribe('LOGIN_SUCCESS', injectControls)

--- a/plugins/dorion-titlebar/waitElm.ts
+++ b/plugins/dorion-titlebar/waitElm.ts
@@ -4,10 +4,15 @@ const {
 
 let observer: MutationObserver | null = null // keep only one observer working
 
+export function disobserve() {
+  observer.disconnect()
+  observer = null
+}
+
 // Observes the DOM for newly added nodes and executes a callback for each.
 function observeDom<T>(rootElm: Node, callbackFn: (node: Node, resolve: (value: T) => void) => boolean, subtree: boolean): Promise<T> {
   return new Promise(resolve => {
-    if (observer) observer.disconnect() // disconnnect old one
+    if (observer) disobserve() // disconnnect old one
 
     observer = new MutationObserver(mutations => {
       for (const mutation of mutations) {
@@ -15,9 +20,7 @@ function observeDom<T>(rootElm: Node, callbackFn: (node: Node, resolve: (value: 
           const addedNodes = Array.from(mutation.addedNodes)
           for (const node of addedNodes) {
             if (!callbackFn(node, resolve)) {
-              observer.disconnect()
-              observer = null
-              return
+              return disobserve()
             }
           }
         }


### PR DESCRIPTION
we still getting this warning, which don't appear without SpikeHD/Dorion#390:
<img width="2321" height="114" alt="image" src="https://github.com/user-attachments/assets/983084f1-5cb0-4905-abbc-b40b4853109c" />

it seems the .-app element somewhat get once be base layer at a moment when Discord start
make it a little bit more specific when searching parents of the bar