### PR TITLE
fix: declutter

### DIFF
--- a/plugins/clean-home/index.tsx
+++ b/plugins/clean-home/index.tsx
@@ -91,6 +91,7 @@ const components = [
     name: 'Server boost bar',
     description: 'Removes the server boost bar',
     rules: `
+      div[data-list-item-id^="channels___skill-"] ~ div { display: none; }
       div[class*="containerWithMargin"][role="button"] { display: none; }
     `
   },


### PR DESCRIPTION
Hi!
I did some work on this.
I did not find first two rules for usernames anywhere, so I left them. Unsure whether they are used.

Gift button is a tricky one. I could use `container` but it would match emoji's `childContainer` whenever it changes capitalization to `childcontainer`, so I propose `-container` as it is the least probable change that can happen in this component (as for now xd).

The server boost progress bar works based on `containerWithMargin`. It's probably the only one in the whole app, but to be sure I added a `role` query.

Fixed: member backgrounds, profile effects, apps and gift buttons, server boost bar (for admins probably)
New: avatar decorations, server boost bar (the progress bar thingy)