### PR TITLE
feat(dorion-settings): add zoom slider percentage tick marks

### DIFF
--- a/plugins/dorion-settings/pages/SettingsPage.tsx
+++ b/plugins/dorion-settings/pages/SettingsPage.tsx
@@ -57,7 +57,7 @@ export function SettingsPage() {
         <WarningCard />
       )}
 
-      <Header class={classes.shead}>{t('dorion_settings.client_type')}</Header>
+      <Header class={classes.shead}>{t('dorion_settings.client_type')} test</Header>
       <RadioGroup
         options={[
           {
@@ -89,27 +89,35 @@ export function SettingsPage() {
 
       <Header class={classes.shead}>{t('dorion_settings.window')}</Header>
       <Header tag={HeaderTags.H4} style="" class={classes.ohead}>{t('dorion_settings.zoom_level')}</Header>
-      <Slider
-        min={50}
-        max={125}
-        steps={
-          Array.from(Array(16).keys()).map(i => (i * 5 + 50) + '%')
-        }
-        step={5}
-        value={parseFloat(settings().zoom) * 100}
-        onInput={(v) => {
-          setSettings(p => {
-            return {
-              ...p,
-              zoom: (parseFloat(v) / 100).toString(),
-            }
-          })
+      <div class={classes.zoomContainer}>
+        <Slider
+          min={50}
+          max={125}
+          steps={
+            Array.from(Array(16).keys()).map(i => (i * 5 + 50) + '%')
+          }
+          step={5}
+          value={parseFloat(settings().zoom) * 100}
+          onInput={(v) => {
+            setSettings(p => {
+              return {
+                ...p,
+                zoom: (parseFloat(v) / 100).toString(),
+              }
+            })
 
-          invoke('window_zoom_level', {
-            value: parseFloat(v) / 100,
-          })
-        }}
-      />
+            invoke('window_zoom_level', {
+              value: parseFloat(v) / 100,
+            })
+          }}
+        />
+        <div class={classes.zoomTicks}>
+          <div class={classes.tick} style="left: 0%"><span>50%</span></div>
+          <div class={classes.tick} style="left: 33.33%"><span>75%</span></div>
+          <div class={classes.tick} style="left: 66.67%"><span>100%</span></div>
+          <div class={classes.tick} style="left: 100%"><span>125%</span></div>
+        </div>
+      </div>
       <SwitchItem
         value={settings().sys_tray}
         onChange={(v) => {

--- a/plugins/dorion-settings/pages/SettingsPage.tsx
+++ b/plugins/dorion-settings/pages/SettingsPage.tsx
@@ -57,7 +57,7 @@ export function SettingsPage() {
         <WarningCard />
       )}
 
-      <Header class={classes.shead}>{t('dorion_settings.client_type')} test</Header>
+      <Header class={classes.shead}>{t('dorion_settings.client_type')}</Header>
       <RadioGroup
         options={[
           {

--- a/plugins/dorion-settings/pages/SettingsPage.tsx.scss
+++ b/plugins/dorion-settings/pages/SettingsPage.tsx.scss
@@ -17,3 +17,33 @@
 .left16 {
   margin-left: 16px;
 }
+
+.zoomContainer {
+  margin-bottom: 16px;
+}
+
+.zoomTicks {
+  position: relative;
+  height: 20px;
+  margin-top: 4px;
+  padding: 0 10px;
+}
+
+.tick {
+  position: absolute;
+  transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  font-size: 10px;
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
+.tick::before {
+  content: '';
+  width: 1px;
+  height: 6px;
+  background-color: var(--text-muted);
+  margin-bottom: 2px;
+}


### PR DESCRIPTION
# Hello !

This PR implement #90 by adding visual scale markers to the zoom slider to improve precision and usability.

## Changes mades
* **Visual tick marker**: Added discrete tick marks at key intervals: 50%, 75%, 100%, and 125%. *(for the zoom slider)*

## Why this is needed
Previously, the zoom slider lacked any scale or numeric feedback, making it difficult for users to gauge the current setting. By adding these markers, the UI now follows the principle of self-evident design, allowing for much higher precision while maintaining the fluid interaction of a slider.

Here's some screenshot:

### BEFORE
<img width="727" height="254" alt="image" src="https://github.com/user-attachments/assets/229f9a92-e1a3-4ec5-9446-a46c53c9cd5c" />

### AFTER 
<img width="725" height="280" alt="image" src="https://github.com/user-attachments/assets/4189f093-3f5d-4286-afd2-153e67373ac4" />
