### PR TITLE
Remove the two scrollbars in inline css editor

### DIFF
--- a/plugins/clean-home/index.tsx
+++ b/plugins/clean-home/index.tsx
@@ -6,7 +6,6 @@ const {
     SwitchItem,
     Header,
     HeaderTags,
-    Text
   }
 } = shelter
 

--- a/plugins/inline-css/components/Editor.scss
+++ b/plugins/inline-css/components/Editor.scss
@@ -5,10 +5,27 @@
   background: var(--background-base-lowest);
 
   height: 80vh !important;
+
+  &[data-popout="true"] {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    height: auto !important;
+    min-height: 0;
+    margin-top: 12px;
+  }
 }
 
 .ceditor > div {
   height: 100% !important;
+}
+
+.ceditor[data-popout="true"] > div {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  height: auto !important;
 }
 
 .controls {
@@ -66,7 +83,21 @@
   }
 }
 
+.ceditor[data-popout="true"] textarea {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+}
+
 .ceditor div[class*="styles-"] {
   height: 100% !important;
   width: 100% !important;
+}
+
+.ceditor[data-popout="true"] div[class*="styles-"] {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  height: auto !important;
 }

--- a/plugins/inline-css/components/Editor.scss
+++ b/plugins/inline-css/components/Editor.scss
@@ -1,6 +1,5 @@
 .ceditor {
   padding: 12px;
-  margin-top: 28px;
   border-radius: 5px;
   background: var(--background-base-lowest);
 
@@ -12,7 +11,8 @@
     flex-direction: column;
     height: auto !important;
     min-height: 0;
-    margin-top: 12px;
+    margin-top: 0;
+    margin-bottom: 12px;
   }
 }
 
@@ -39,6 +39,11 @@
   & button {
     width: 30%;
   }
+}
+
+.ceditor[data-popout="true"] .controls {
+  margin-top: 12px;
+  margin-bottom: 12px;
 }
 
 .popout {
@@ -86,7 +91,9 @@
 .ceditor[data-popout="true"] textarea {
   flex: 1;
   min-height: 0;
+  max-height: 100%;
   overflow-y: auto;
+  height: auto !important;
 }
 
 .ceditor div[class*="styles-"] {

--- a/plugins/inline-css/components/Editor.scss
+++ b/plugins/inline-css/components/Editor.scss
@@ -90,8 +90,7 @@
 
 .ceditor[data-popout="true"] textarea {
   flex: 1;
-  min-height: 0;
-  max-height: 100%;
+  min-height: 100%;
   overflow-y: auto;
   height: auto !important;
 }

--- a/plugins/inline-css/components/Editor.tsx
+++ b/plugins/inline-css/components/Editor.tsx
@@ -112,7 +112,7 @@ export default function (props: Props) {
         </Button>
       </div>
 
-      <div class={classes.ceditor} ref={ref} data-popout={props.popout ? "true" : "false"}>
+      <div class={classes.ceditor} ref={ref} data-popout={props.popout ? 'true' : 'false'}>
         <CodeInput
           highlightjs={hljs}
           autoHeight={false}

--- a/plugins/inline-css/components/Editor.tsx
+++ b/plugins/inline-css/components/Editor.tsx
@@ -112,7 +112,7 @@ export default function (props: Props) {
         </Button>
       </div>
 
-      <div class={classes.ceditor} ref={ref}>
+      <div class={classes.ceditor} ref={ref} data-popout={props.popout ? "true" : "false"}>
         <CodeInput
           highlightjs={hljs}
           autoHeight={false}

--- a/plugins/inline-css/components/Window.scss
+++ b/plugins/inline-css/components/Window.scss
@@ -35,36 +35,16 @@
 
   box-shadow: 0 0 3px 0 rgba(0, 0, 0);
 
+  display: flex;
+  flex-direction: column;
+
   & .inner {
     margin: 8px;
-    overflow-y: auto;
-    height: calc(100% - 50px);
-
-    /* Scrollbar */
-    &::-webkit-scrollbar-corner {
-      background: transparent
-    }
-  
-    &::-webkit-scrollbar {
-      background: transparent;
-    }
-  
-    &::-webkit-scrollbar-track {
-      background: none;
-    }
-  
-    &::-webkit-scrollbar-thumb {
-      background: var(--background-base-lowest);
-      border-radius: 4px;
-    }
-  
-    &::-webkit-scrollbar:horizontal {
-      height: 8px;
-    }
-  
-    &::-webkit-scrollbar:vertical {
-      width: 8px;
-    }
+    flex: 1;
+    min-height: 0;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
   }
 }
 
@@ -96,4 +76,8 @@
 
 .main {
   margin-right: 10px;
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
 }


### PR DESCRIPTION
## Summary
This PR fixes the double scrollbar issue in the CSS editor when using popout mode (issue #33).

## Problem
The CSS editor was displaying two scrollbars simultaneously:
* One for the text field
* One for the floating window

## Reproduction
1. Open the CSS editor
2. Paste a long CSS snippet
3. Click the "Pop Out" button
4. Observe the two scrollbars

## Implemented solution
Restructured the layout using flexbox so that:
* The editor fills all available space in the window
* Only the textarea scrolls (single scrollbar)
* The popout window adapts dynamically to its size

## Benefits
* Single scrollbar as expected
* Editor adapts to window size
* Better user experience

**BEFORE**
<img width="587" height="424" alt="Capture d’écran 2026-05-01 à 20 31 41" src="https://github.com/user-attachments/assets/6b8d5dcf-f028-44b4-8324-ee839e72df9a" />

**AFTER**
<img width="527" height="483" alt="Capture d’écran 2026-05-01 à 20 30 57" src="https://github.com/user-attachments/assets/0c673dd4-d1fe-4b01-8692-d007b215d9e8" />
