### PR TITLE
Migrate from custom editor to monaco editor

### DIFF
--- a/plugins/inline-css/components/Editor.scss
+++ b/plugins/inline-css/components/Editor.scss
@@ -1,8 +1,6 @@
 .ceditor {
-  padding: 12px;
   border-radius: 5px;
-  background: var(--background-base-lowest);
-
+  margin-top: 20px;
   height: 80vh !important;
 
   &[data-popout="true"] {
@@ -24,6 +22,16 @@
   flex: 1;
   display: flex;
   flex-direction: column;
+  min-height: 0;
+  height: auto !important;
+}
+
+.ceditor .monaco-editor {
+  height: 100% !important;
+}
+
+.ceditor[data-popout="true"] .monaco-editor {
+  flex: 1;
   min-height: 0;
   height: auto !important;
 }
@@ -54,56 +62,4 @@
     height: 50%;
     width: 30px;
   }
-}
-
-.ceditor textarea {
-  height: 100% !important;
-  cursor: auto;
-
-  color: transparent;
-
-  &::-webkit-scrollbar-corner {
-    background: transparent
-  }
-
-  &::-webkit-scrollbar {
-    background: transparent;
-  }
-
-  &::-webkit-scrollbar-track {
-    background: none;
-  }
-
-  &::-webkit-scrollbar-thumb {
-    background: var(--primary-530);
-    border-radius: 4px;
-  }
-
-  &::-webkit-scrollbar:horizontal {
-    height: 8px;
-  }
-
-  &::-webkit-scrollbar:vertical {
-    width: 8px;
-  }
-}
-
-.ceditor[data-popout="true"] textarea {
-  flex: 1;
-  min-height: 100%;
-  overflow-y: auto;
-  height: auto !important;
-}
-
-.ceditor div[class*="styles-"] {
-  height: 100% !important;
-  width: 100% !important;
-}
-
-.ceditor[data-popout="true"] div[class*="styles-"] {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  min-height: 0;
-  height: auto !important;
 }

--- a/plugins/inline-css/components/Editor.scss
+++ b/plugins/inline-css/components/Editor.scss
@@ -28,6 +28,15 @@
 
 .ceditor .monaco-editor {
   height: 100% !important;
+
+  .line-numbers {
+    text-align: right !important;
+    padding-right: 4px !important;
+  }
+
+  .glyph-margin {
+    width: 0px !important;
+  }
 }
 
 .ceditor[data-popout="true"] .monaco-editor {

--- a/plugins/inline-css/components/Editor.tsx
+++ b/plugins/inline-css/components/Editor.tsx
@@ -66,6 +66,11 @@ export default function (props: Props) {
           automaticLayout: true,
           scrollBeyondLastLine: false,
           lineNumbers: 'on',
+          lineNumbersMinChars: 3,
+          lineDecorationsWidth: 5,
+          showFoldingControls: 'mouseover',
+          glyphMargin: false,
+          folding: false,
           wordWrap: 'on'
         })
 

--- a/plugins/inline-css/components/Editor.tsx
+++ b/plugins/inline-css/components/Editor.tsx
@@ -61,52 +61,50 @@ export default function (props: Props) {
     observer.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] })
     onCleanup(() => observer.disconnect())
 
-    requestAnimationFrame(() => {
-      const container = ref
-      if (!container || editorInstance) return
+    const container = ref
+    if (!container || editorInstance) return
 
-      loader.init().then((monaco) => {
-        if (editorInstance) {
-          editorInstance.dispose()
-        }
+    loader.init().then((monaco) => {
+      if (editorInstance) {
+        editorInstance.dispose()
+      }
 
-        editorInstance = monaco.editor.create(container, {
-          value: store.inlineCss || '',
-          language: 'css',
-          theme: isDark() ? 'vs-dark' : 'vs',
-          minimap: { enabled: false },
-          fontSize: 14,
-          automaticLayout: true,
-          scrollBeyondLastLine: false,
-          lineNumbers: 'on',
-          lineNumbersMinChars: 3,
-          lineDecorationsWidth: 5,
-          glyphMargin: false,
-          folding: true,
-          wordWrap: 'on'
-        })
-
-        createEffect(() => {
-          if (editorInstance) {
-            editorInstance.updateOptions({
-              theme: isDark() ? 'vs-dark' : 'vs'
-            })
-          }
-        })
-
-        editorInstance.onDidChangeModelContent(() => {
-          const value = editorInstance.getValue()
-          if (hotReload()) {
-            saveCss(value, props.styleElm)
-          }
-        })
+      editorInstance = monaco.editor.create(container, {
+        value: store.inlineCss || '',
+        language: 'css',
+        theme: isDark() ? 'vs-dark' : 'vs',
+        minimap: { enabled: false },
+        fontSize: 14,
+        automaticLayout: true,
+        scrollBeyondLastLine: false,
+        lineNumbers: 'on',
+        lineNumbersMinChars: 3,
+        lineDecorationsWidth: 5,
+        glyphMargin: false,
+        folding: true,
+        wordWrap: 'on'
       })
 
-      onCleanup(() => {
+      createEffect(() => {
         if (editorInstance) {
-          editorInstance.dispose()
+          editorInstance.updateOptions({
+            theme: isDark() ? 'vs-dark' : 'vs'
+          })
         }
       })
+
+      editorInstance.onDidChangeModelContent(() => {
+        const value = editorInstance.getValue()
+        if (hotReload()) {
+          saveCss(value, props.styleElm)
+        }
+      })
+    })
+
+    onCleanup(() => {
+      if (editorInstance) {
+        editorInstance.dispose()
+      }
     })
   })
 

--- a/plugins/inline-css/components/Editor.tsx
+++ b/plugins/inline-css/components/Editor.tsx
@@ -61,50 +61,52 @@ export default function (props: Props) {
     observer.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] })
     onCleanup(() => observer.disconnect())
 
-    const container = ref
-    if (!container || editorInstance) return
+    requestAnimationFrame(() => {
+      const container = ref
+      if (!container || editorInstance) return
 
-    loader.init().then((monaco) => {
-      if (editorInstance) {
-        editorInstance.dispose()
-      }
-
-      editorInstance = monaco.editor.create(container, {
-        value: store.inlineCss || '',
-        language: 'css',
-        theme: isDark() ? 'vs-dark' : 'vs',
-        minimap: { enabled: false },
-        fontSize: 14,
-        automaticLayout: true,
-        scrollBeyondLastLine: false,
-        lineNumbers: 'on',
-        lineNumbersMinChars: 3,
-        lineDecorationsWidth: 5,
-        glyphMargin: false,
-        folding: true,
-        wordWrap: 'on'
-      })
-
-      createEffect(() => {
+      loader.init().then((monaco) => {
         if (editorInstance) {
-          editorInstance.updateOptions({
-            theme: isDark() ? 'vs-dark' : 'vs'
-          })
+          editorInstance.dispose()
         }
+
+        editorInstance = monaco.editor.create(container, {
+          value: store.inlineCss || '',
+          language: 'css',
+          theme: isDark() ? 'vs-dark' : 'vs',
+          minimap: { enabled: false },
+          fontSize: 14,
+          automaticLayout: true,
+          scrollBeyondLastLine: false,
+          lineNumbers: 'on',
+          lineNumbersMinChars: 3,
+          lineDecorationsWidth: 5,
+          glyphMargin: false,
+          folding: true,
+          wordWrap: 'on'
+        })
+
+        createEffect(() => {
+          if (editorInstance) {
+            editorInstance.updateOptions({
+              theme: isDark() ? 'vs-dark' : 'vs'
+            })
+          }
+        })
+
+        editorInstance.onDidChangeModelContent(() => {
+          const value = editorInstance.getValue()
+          if (hotReload()) {
+            saveCss(value, props.styleElm)
+          }
+        })
       })
 
-      editorInstance.onDidChangeModelContent(() => {
-        const value = editorInstance.getValue()
-        if (hotReload()) {
-          saveCss(value, props.styleElm)
+      onCleanup(() => {
+        if (editorInstance) {
+          editorInstance.dispose()
         }
       })
-    })
-
-    onCleanup(() => {
-      if (editorInstance) {
-        editorInstance.dispose()
-      }
     })
   })
 

--- a/plugins/inline-css/components/Editor.tsx
+++ b/plugins/inline-css/components/Editor.tsx
@@ -19,7 +19,7 @@ const {
     CheckboxItem
   },
   plugin: { store },
-  solid: { createSignal, onMount, onCleanup },
+  solid: { createSignal, createEffect, onMount, onCleanup },
   flux: {
     dispatcher
   }
@@ -35,6 +35,10 @@ const saveCss = debounce((css: string, styleElm: HTMLStyleElement) => {
 
 let injectedCss = false
 
+const getDiscordTheme = (): boolean => {
+  return document.documentElement.classList.contains('theme-dark')
+}
+
 export default function (props: Props) {
   // eslint-disable-next-line prefer-const
   let ref: HTMLDivElement | undefined = null
@@ -46,8 +50,17 @@ export default function (props: Props) {
   }
 
   const [hotReload, setHotReload] = createSignal(true)
+  const [isDark, setIsDark] = createSignal(true)
 
   onMount(() => {
+    setIsDark(getDiscordTheme())
+
+    const observer = new MutationObserver(() => {
+      setIsDark(getDiscordTheme())
+    })
+    observer.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] })
+    onCleanup(() => observer.disconnect())
+
     requestAnimationFrame(() => {
       const container = ref
       if (!container || editorInstance) return
@@ -60,7 +73,7 @@ export default function (props: Props) {
         editorInstance = monaco.editor.create(container, {
           value: store.inlineCss || '',
           language: 'css',
-          theme: 'vs-dark',
+          theme: isDark() ? 'vs-dark' : 'vs',
           minimap: { enabled: false },
           fontSize: 14,
           automaticLayout: true,
@@ -71,6 +84,14 @@ export default function (props: Props) {
           glyphMargin: false,
           folding: true,
           wordWrap: 'on'
+        })
+
+        createEffect(() => {
+          if (editorInstance) {
+            editorInstance.updateOptions({
+              theme: isDark() ? 'vs-dark' : 'vs'
+            })
+          }
         })
 
         editorInstance.onDidChangeModelContent(() => {

--- a/plugins/inline-css/components/Editor.tsx
+++ b/plugins/inline-css/components/Editor.tsx
@@ -1,6 +1,4 @@
-import { CodeInput } from '@srsholmes/solid-code-input'
-import hljs from 'highlight.js/lib/core'
-import cssModule from 'highlight.js/lib/languages/css'
+import loader from '@monaco-editor/loader'
 
 import {css, classes} from './Editor.scss'
 import { debounce } from '../../../util/debounce.js'
@@ -12,8 +10,6 @@ interface Props {
   popout?: boolean
 }
 
-hljs.registerLanguage('css', cssModule)
-
 const {
   ui: {
     injectCss,
@@ -23,7 +19,7 @@ const {
     CheckboxItem
   },
   plugin: { store },
-  solid: { createSignal, createEffect },
+  solid: { createSignal, onMount, onCleanup },
   flux: {
     dispatcher
   }
@@ -41,31 +37,59 @@ let injectedCss = false
 
 export default function (props: Props) {
   // eslint-disable-next-line prefer-const
-  let ref = null
+  let ref: HTMLDivElement | undefined = null
+  let editorInstance: any = null
 
   if (!injectedCss) {
     injectCss(css)
     injectedCss = true
   }
 
-  const [inlineCss, setInlineCss] = createSignal('')
   const [hotReload, setHotReload] = createSignal(true)
 
-  createEffect(() => {
-    setInlineCss(store.inlineCss)
+  onMount(() => {
+    requestAnimationFrame(() => {
+      const container = ref
+      if (!container || editorInstance) return
+
+      loader.init().then((monaco) => {
+        if (editorInstance) {
+          editorInstance.dispose()
+        }
+
+        editorInstance = monaco.editor.create(container, {
+          value: store.inlineCss || '',
+          language: 'css',
+          theme: 'vs-dark',
+          minimap: { enabled: false },
+          fontSize: 14,
+          automaticLayout: true,
+          scrollBeyondLastLine: false,
+          lineNumbers: 'on',
+          wordWrap: 'on'
+        })
+
+        editorInstance.onDidChangeModelContent(() => {
+          const value = editorInstance.getValue()
+          if (hotReload()) {
+            saveCss(value, props.styleElm)
+          }
+        })
+      })
+
+      onCleanup(() => {
+        if (editorInstance) {
+          editorInstance.dispose()
+        }
+      })
+    })
   })
 
-  const setCss = (css: string) => {
-    if (ref) {
-      // Find the textarea in the ref, and autoscroll down
-      const textarea = ref.querySelector('textarea')
-      if (textarea && textarea.scrollTop !== textarea.scrollHeight) {
-        textarea.scrollTop = textarea.scrollHeight
-      }
+  const setCss = () => {
+    if (editorInstance) {
+      const value = editorInstance.getValue()
+      saveCss(value, props.styleElm)
     }
-
-    setInlineCss(css)
-    saveCss(css, props.styleElm)
   }
 
   return (
@@ -81,7 +105,6 @@ export default function (props: Props) {
                 Window()
               )
 
-              // This closes settings automagically
               dispatcher.dispatch({
                 type: 'LAYER_POP'
               })
@@ -102,27 +125,14 @@ export default function (props: Props) {
         </CheckboxItem>
 
         <Button
-          onClick={() => {
-            // Save inline CSS
-            setCss(inlineCss())
-          }}
+          onClick={setCss}
           disabled={hotReload()}
         >
           Save & Apply
         </Button>
       </div>
 
-      <div class={classes.ceditor} ref={ref} data-popout={props.popout ? 'true' : 'false'}>
-        <CodeInput
-          highlightjs={hljs}
-          autoHeight={false}
-          resize="none"
-          placeholder="Enter any CSS here..."
-          onChange={hotReload() ? setCss : setInlineCss}
-          value={inlineCss()}
-          language={'css'}
-        />
-      </div>
+      <div class={classes.ceditor} ref={ref} data-popout={props.popout ? 'true' : 'false'} />
     </>
   )
 }

--- a/plugins/inline-css/components/Editor.tsx
+++ b/plugins/inline-css/components/Editor.tsx
@@ -68,9 +68,8 @@ export default function (props: Props) {
           lineNumbers: 'on',
           lineNumbersMinChars: 3,
           lineDecorationsWidth: 5,
-          showFoldingControls: 'mouseover',
           glyphMargin: false,
-          folding: false,
+          folding: true,
           wordWrap: 'on'
         })
 

--- a/plugins/inline-css/index.tsx
+++ b/plugins/inline-css/index.tsx
@@ -9,14 +9,7 @@ const {
   }
 } = shelter
 
-let styleElm: HTMLStyleElement | null = null
-
-// Silly little styling tweak for the code editor
-const style = document.createElement('style')
-style.textContent = '.code-highlighted { color: var(--text-default) }'
-styleElm = document.body.appendChild(style)
-
-// Also create another style element to contain the CSS
+// Create style element to contain the CSS
 let inlineStyleElm: HTMLStyleElement | null = null
 const inlineStyle = document.createElement('style')
 inlineStyle.id = 'inline-css-output'
@@ -29,10 +22,6 @@ const unload = registerSection('section', 'inline-css', 'CSS Editor', () => Edit
 
 export const onUnload = () => {
   unload()
-
-  if (styleElm) {
-    styleElm.remove()
-  }
 
   if (inlineStyleElm) {
     inlineStyleElm.remove()

--- a/plugins/inline-css/package.json
+++ b/plugins/inline-css/package.json
@@ -1,8 +1,7 @@
 {
   "name": "inline-css",
   "dependencies": {
-    "@srsholmes/solid-code-input": "^0.0.18",
-    "highlight.js": "^11.9.0"
+    "@monaco-editor/loader": "^1.4.0"
   },
   "type": "module"
 }

--- a/plugins/inline-css/package.json
+++ b/plugins/inline-css/package.json
@@ -1,7 +1,7 @@
 {
   "name": "inline-css",
   "dependencies": {
-    "@monaco-editor/loader": "^1.4.0"
+    "@monaco-editor/loader": "^1.7.0"
   },
   "type": "module"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,12 +57,9 @@ importers:
 
   plugins/inline-css:
     dependencies:
-      '@srsholmes/solid-code-input':
-        specifier: ^0.0.18
-        version: 0.0.18(@types/highlight.js@9.12.2)(@types/prismjs@1.26.0)(solid-js@1.8.7)
-      highlight.js:
-        specifier: ^11.9.0
-        version: 11.9.0
+      '@monaco-editor/loader':
+        specifier: ^1.4.0
+        version: 1.7.0
 
   plugins/platform-spoof:
     dependencies:
@@ -439,6 +436,9 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@monaco-editor/loader@1.7.0':
+    resolution: {integrity: sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA==}
+
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
@@ -584,13 +584,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@srsholmes/solid-code-input@0.0.18':
-    resolution: {integrity: sha512-9qmWg7gL8f+wfUJjzikoYNMbcqewxzau50jGaUdYbqNLcQrAmbQLbwxCtwybZi/qoIVUWcSAEalD21y0ye+KJw==}
-    peerDependencies:
-      '@types/highlight.js': 9.12.2
-      '@types/prismjs': 1.26.0
-      solid-js: ^1.6.10
-
   '@tauri-apps/api@1.6.0':
     resolution: {integrity: sha512-rqI++FWClU5I2UBp4HXFvl+sBWkdigBkxnpJDQUWttNyG7IZP4FwQGhTNL5EOw0vI8i6eSAJ5frLqO7n7jbJdg==}
     engines: {node: '>= 14.6.0', npm: '>= 6.6.0', yarn: '>= 1.19.1'}
@@ -601,14 +594,8 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
-  '@types/highlight.js@9.12.2':
-    resolution: {integrity: sha512-y5x0XD/WXDaGSyiTaTcKS4FurULJtSiYbGTeQd0m2LYZGBcZZ/7fM6t5H/DzeUF+kv8y6UfmF6yJABQsHcp9VQ==}
-
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
-
-  '@types/prismjs@1.26.0':
-    resolution: {integrity: sha512-ZTaqn/qSqUuAq1YwvOFQfVW1AR/oQJlLSZVustdjwI+GZ8kr0MSHBj0tsXPW1EqHubx50gtBEjbPGsdZwQwCjQ==}
 
   '@typescript-eslint/eslint-plugin@8.50.1':
     resolution: {integrity: sha512-PKhLGDq3JAg0Jk/aK890knnqduuI/Qj+udH7wCf0217IGi4gt+acgCyPVe79qoT+qKUvHMDQkwJeKW9fwl8Cyw==}
@@ -920,10 +907,6 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
-  highlight.js@11.9.0:
-    resolution: {integrity: sha512-fJ7cW7fQGCYAkgv4CPfwFHrfd/cLS4Hau96JuJ+ZTOWhjnhoeN1ub1tFmALm/+lW5z4WCAuAV9bm05AP0mS6Gw==}
-    engines: {node: '>=12.0.0'}
-
   idb@7.1.1:
     resolution: {integrity: sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==}
 
@@ -1200,10 +1183,6 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  seroval@0.15.1:
-    resolution: {integrity: sha512-OPVtf0qmeC7RW+ScVX+7aOS+xoIM7pWcZ0jOWg2aTZigCydgRB04adfteBRbecZnnrO1WuGQ+C3tLeBBzX2zSQ==}
-    engines: {node: '>=10'}
-
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -1215,9 +1194,6 @@ packages:
   solid-js@1.6.16:
     resolution: {integrity: sha512-Ng4CahvLlpGA3BXIMiiMdwhI8WpObZ8gXqm97GCKR4+MpnODs6Pdpco+tmVCY/4ZDFaEKDxz7WRLAAdoXdlY7w==}
 
-  solid-js@1.8.7:
-    resolution: {integrity: sha512-9dzrSVieh2zj3SnJ02II6xZkonR6c+j/91b7XZUNcC6xSaldlqjjGh98F1fk5cRJ8ZTkzqF5fPIWDxEOs6QZXA==}
-
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -1227,6 +1203,9 @@ packages:
 
   spitroast@2.1.6:
     resolution: {integrity: sha512-xil2XeVh8WQoBlG8Lm8jT6ifqWGmSgTGq2clRcq2roycb0kg1h4fv5ydoiBId9kIQp4Y12PK/cjVzD8xpWXZvg==}
+
+  state-local@1.0.7:
+    resolution: {integrity: sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==}
 
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -1654,6 +1633,10 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@monaco-editor/loader@1.7.0':
+    dependencies:
+      state-local: 1.0.7
+
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
       '@emnapi/core': 1.7.1
@@ -1760,12 +1743,6 @@ snapshots:
   '@rolldown/binding-win32-x64-msvc@1.0.0-beta.1':
     optional: true
 
-  '@srsholmes/solid-code-input@0.0.18(@types/highlight.js@9.12.2)(@types/prismjs@1.26.0)(solid-js@1.8.7)':
-    dependencies:
-      '@types/highlight.js': 9.12.2
-      '@types/prismjs': 1.26.0
-      solid-js: 1.8.7
-
   '@tauri-apps/api@1.6.0': {}
 
   '@tybys/wasm-util@0.10.1':
@@ -1775,11 +1752,7 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
-  '@types/highlight.js@9.12.2': {}
-
   '@types/json-schema@7.0.15': {}
-
-  '@types/prismjs@1.26.0': {}
 
   '@typescript-eslint/eslint-plugin@8.50.1(@typescript-eslint/parser@8.50.1(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2)(typescript@5.9.3)':
     dependencies:
@@ -2154,8 +2127,6 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  highlight.js@11.9.0: {}
-
   idb@7.1.1: {}
 
   ignore@5.3.2: {}
@@ -2380,8 +2351,6 @@ snapshots:
 
   semver@7.7.3: {}
 
-  seroval@0.15.1: {}
-
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
@@ -2392,16 +2361,13 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
-  solid-js@1.8.7:
-    dependencies:
-      csstype: 3.2.3
-      seroval: 0.15.1
-
   source-map-js@1.2.1: {}
 
   spitroast@1.4.4: {}
 
   spitroast@2.1.6: {}
+
+  state-local@1.0.7: {}
 
   strip-json-comments@3.1.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,7 +58,7 @@ importers:
   plugins/inline-css:
     dependencies:
       '@monaco-editor/loader':
-        specifier: ^1.4.0
+        specifier: ^1.7.0
         version: 1.7.0
 
   plugins/platform-spoof:


### PR DESCRIPTION
# Hello !

This PR introduces a migration from the current inline CSS editor to Monaco Editor, following the proposal discussed in #93.

The goal is pretty straightforward. The existing editor starts to break down as soon as the CSS becomes more complex. Scrolling becomes unreliable as described in #23, and there is still no proper search support as mentioned in #7. These aren’t isolated issues, they come from the limitations of the current approach.

Instead of patching those problems one by one, this PR replaces the editor with something that is designed for this exact use case.

## What changes

The textarea-based editor powered by highlight.js is replaced with Monaco. The rest of the flow stays the same from a user perspective, but the editing experience is significantly improved.

You get stable scrolling even with large files, built-in search with Ctrl+F, and a generally more reliable editor. It also brings better syntax handling and fewer edge cases when editing longer CSS.

## How it works

The integration is intentionally kept lightweight. Monaco is not bundled into the plugin. It is loaded on demand using `@monaco-editor/loader`.

When the user opens the CSS editor, Monaco is fetched from the CDN and initialized inside the existing component. Once loaded, it is cached by the browser, so reopening the editor is instant.

Changes in the editor are listened to and saved using a small debounce to avoid excessive updates. The current hot reload behavior is preserved, so styles can still be applied live or manually depending on the setting. When the component unmounts, the editor instance is properly disposed.

## Why this approach

The main advantage is that it solves multiple problems at once instead of introducing more custom logic to maintain.

Trying to fix scrolling or implement search manually would add complexity on top of an already limited editor. Monaco already provides these features in a much more stable way, so the trade-off here is to rely on an upstream solution rather than maintaining our own.

## Trade-offs

Monaco is heavier than the current setup and depends on a CDN. This is the main concern raised in #93.

That said, because it is lazy-loaded, it does not affect the initial load of Discord. The editor is only downloaded when needed, and in practice the loading time remains acceptable for this kind of feature.

There is also a balance between control and simplicity. Using a CDN avoids increasing the bundle size and keeps the integration simple, but it introduces an external dependency.

## Final note

This PR doesn’t try to redesign the whole CSS workflow. It focuses on replacing a fragile part of the stack with something more robust, while keeping the integration minimal and consistent with the existing behavior.

The idea is to improve reliability and reduce long-term maintenance rather than continuously patching the current editor.

## Preview
<img width="1305" height="943" alt="Capture d’écran 2026-05-01 à 22 46 41" src="https://github.com/user-attachments/assets/5330dec1-b789-40fd-a458-4867a69611eb" />
<img width="1829" height="1000" alt="Capture d’écran 2026-05-01 à 22 47 36" src="https://github.com/user-attachments/assets/214ffa8d-047d-4b28-8285-851a905d639d" />