### PR TITLE
feat(userpfp): add database source option

### DIFF
--- a/plugins/userpfp/index.scss
+++ b/plugins/userpfp/index.scss
@@ -2,3 +2,7 @@
   margin-bottom: 10px;
   display: inline-block;
 }
+
+.settingItem {
+  margin: 10px 0;
+}

--- a/plugins/userpfp/index.tsx
+++ b/plugins/userpfp/index.tsx
@@ -7,13 +7,14 @@ const {
     SwitchItem,
     LinkButton,
     injectCss,
+    TextBox,
   },
   plugin: {
     store
   }
 } = shelter
 
-const DATA_URL = 'https://userpfp.github.io/UserPFP/source/data.json'
+const DEFAULT_DATA_URL = 'https://userpfp.github.io/UserPFP/source/data.json'
 
 const chunk = webpackChunk()
 const wp = chunk && createApi([undefined, ...chunk])
@@ -50,6 +51,15 @@ export const settings = () => (
       Submit your PFP here!
     </LinkButton>
 
+    <div class={classes.settingItem}>
+      <TextBox
+        type="text"
+        value={store.databaseUrl || ''}
+        onInput={(v: any) => (store.databaseUrl = v)}
+        placeholder="Custom database URL (optional)"
+      />
+    </div>
+
     <SwitchItem
       value={store.preferNitro}
       onChange={(v) => (store.preferNitro = v)}
@@ -61,7 +71,8 @@ export const settings = () => (
 )
 
 export const onLoad = async () => {
-  const resp = await fetch(DATA_URL)
+  const dataUrl = store.databaseUrl || DEFAULT_DATA_URL
+  const resp = await fetch(dataUrl)
   window.userpfp = await resp.json()
   window.userpfp.getUrl = (id: string) => window.userpfp.avatars[id] ?? null
 }


### PR DESCRIPTION
# Hello !
This PR addresses the request in #54.

I've added a new setting that allows us to define the database source via a URL. This should give us the flexibility we need for handling different data sources more dynamically.

Let me know if the implementation looks good to you or if you have any suggestions!

## Preview
<img width="1301" height="899" alt="Capture d’écran 2026-05-02 à 22 54 53" src="https://github.com/user-attachments/assets/33096f87-9698-4dee-acaf-f6b2bf4482a1" />
