### PR TITLE
feat: add tick to the zoom slider

### DIFF
--- a/plugins/dorion-settings/pages/SettingsPage.tsx
+++ b/plugins/dorion-settings/pages/SettingsPage.tsx
@@ -109,6 +109,7 @@ export function SettingsPage() {
             value: parseFloat(v) / 100,
           })
         }}
+        tick={25}
       />
       <SwitchItem
         value={settings().sys_tray}


### PR DESCRIPTION
## Hello!
This pull request adds the `tick` property to the zoom slider with a value of 25 (which should render the tick for 50, 75, 100, and 125). 

## Note
It is not intended to be merged right now because it will not work until [this issue](https://github.com/uwu/shelter/issues/70) is solved. 

Fixes #90 