### PR TITLE
refactor(dorion-settings): move refresh button inline with header using flexbox

### DIFF
--- a/plugins/dorion-settings/pages/ChangelogPage.tsx
+++ b/plugins/dorion-settings/pages/ChangelogPage.tsx
@@ -1,8 +1,12 @@
-import { invoke,app, appName } from '../../../api/api.js'
+import { invoke, app, appName } from '../../../api/api.js'
 import { t } from '../../../util/i18n.js'
 import type { IRelease, TReleases } from '../types/release.js'
 import { css, classes } from './ChangelogPage.tsx.scss'
-import { processReleaseBodies, loadChangelog, fixImageLinks } from '../util/changelog.js'
+import {
+  processReleaseBodies,
+  loadChangelog,
+  fixImageLinks,
+} from '../util/changelog.js'
 
 const PAGE_ID = `${appName.toLowerCase()}-changelog-tab`
 
@@ -15,7 +19,7 @@ const {
     ButtonSizes,
     ButtonColors,
     Text,
-    LinkButton
+    LinkButton,
   },
   solid: { createSignal, createEffect },
 } = shelter
@@ -59,7 +63,7 @@ export function ChangelogPage() {
 
   async function doUpdate() {
     invoke('do_update', {
-      toUpdate: updateCheck()
+      toUpdate: updateCheck(),
     })
   }
 
@@ -72,8 +76,12 @@ export function ChangelogPage() {
 
   return (
     <>
-      <Header tag={HeaderTags.H1} class={classes.tophead}>{t('dorion_changelog.title')}</Header>
-      <Button onClick={refresh} disabled={loading()} class={classes.refresh}>{t('dorion_changelog.refresh')}</Button>
+      <Header tag={HeaderTags.H1} class={classes.tophead}>
+        {t('dorion_changelog.title')}
+        <Button onClick={refresh} disabled={loading()}>
+          {t('dorion_changelog.refresh')}
+        </Button>
+      </Header>
       {loading() ? (
         <div class={classes.card}>
           <div class={classes.spinner} />
@@ -82,28 +90,48 @@ export function ChangelogPage() {
         <>
           {updateCheck().includes('dorion') && (
             <div class={classes.card}>
-              <Header tag={HeaderTags.H1} class={classes.title}>{t('dorion_changelog.update_available')}</Header>
-              <Text>{t('dorion_changelog.current_version', { version: currentVersion() })}</Text>
-              <Button size={ButtonSizes.LARGE} color={ButtonColors.GREEN} onClick={doUpdate}>{t('dorion_changelog.update_to', { version: latestVersion() } )}</Button>
+              <Header tag={HeaderTags.H1} class={classes.title}>
+                {t('dorion_changelog.update_available')}
+              </Header>
+              <Text>
+                {t('dorion_changelog.current_version', {
+                  version: currentVersion(),
+                })}
+              </Text>
+              <Button
+                size={ButtonSizes.LARGE}
+                color={ButtonColors.GREEN}
+                onClick={doUpdate}
+              >
+                {t('dorion_changelog.update_to', { version: latestVersion() })}
+              </Button>
             </div>
           )}
-          {releases() != null && releases().length > 0 && releases().map((release: IRelease) => (
-            <div class={classes.card}>
-              <Header tag={HeaderTags.H1} class={classes.title}>
-                <span>
-                  {release.name}
-                </span>
-                <div class={classes.badges}>
-                  {currentVersion() == release.tag_name &&
-                    <span class={classes.badge}>{t('dorion_changelog.current')}</span>}
-                  {releases()[0].tag_name == release.tag_name &&
-                    <span class={classes.badge}>{t('dorion_changelog.latest')}</span>}
-                </div>
-              </Header>
-              <LinkButton href={release.html_url}>{t('dorion_changelog.view_on_github')}</LinkButton>
-              <div class={classes.contents} innerHTML={release.body} />
-            </div>
-          ))}
+          {releases() != null &&
+            releases().length > 0 &&
+            releases().map((release: IRelease) => (
+              <div class={classes.card}>
+                <Header tag={HeaderTags.H1} class={classes.title}>
+                  <span>{release.name}</span>
+                  <div class={classes.badges}>
+                    {currentVersion() == release.tag_name && (
+                      <span class={classes.badge}>
+                        {t('dorion_changelog.current')}
+                      </span>
+                    )}
+                    {releases()[0].tag_name == release.tag_name && (
+                      <span class={classes.badge}>
+                        {t('dorion_changelog.latest')}
+                      </span>
+                    )}
+                  </div>
+                </Header>
+                <LinkButton href={release.html_url}>
+                  {t('dorion_changelog.view_on_github')}
+                </LinkButton>
+                <div class={classes.contents} innerHTML={release.body} />
+              </div>
+            ))}
         </>
       )}
     </>

--- a/plugins/dorion-settings/pages/ChangelogPage.tsx.scss
+++ b/plugins/dorion-settings/pages/ChangelogPage.tsx.scss
@@ -1,11 +1,8 @@
 .tophead {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
   margin-bottom: 16px;
-}
-
-.refresh {
-  position: absolute;
-  top: 52px;
-  right: 40px;
 }
 
 .card {


### PR DESCRIPTION
# Hello!
This PR moves the refresh button alongside the header using flexbox, which removes the weird glitch where the button was cut. 

## Preview
<img width="1425" height="917" alt="Capture d’écran 2026-05-03 à 16 13 21" src="https://github.com/user-attachments/assets/c6a96e0d-308f-4a81-89a6-8270776c045d" />

## Note
Fixes [#465](https://github.com/SpikeHD/Dorion/issues/465) *(in dorion repo)*
