### PR TITLE
feat: remove the option to enable or disable shelter client mod

### DIFF
--- a/plugins/dorion-settings/components/ClientModList.tsx
+++ b/plugins/dorion-settings/components/ClientModList.tsx
@@ -89,26 +89,13 @@ export function ClientModList(props: Props) {
     )}
 
     {clientMods().map((modName: string) => {
-      const isVencordOrEquicord = modName === 'Vencord' || modName === 'Equicord'
-      const isMutuallyExcluded = isVencordOrEquicord && (
-        (modName === 'Vencord' && settings().client_mods?.includes('Equicord')) ||
-        (modName === 'Equicord' && settings().client_mods?.includes('Vencord'))
-      )
-
-      let note = ''
-
       if (modName === 'Shelter') {
-        note = 'Shelter is required for Dorion to function properly.'
+        return null
       }
 
       return (
         <SwitchItem
-          disabled={modName === 'Shelter' || isMutuallyExcluded}
-          value={settings().client_mods?.includes(modName) || false}
-          onChange={() =>
-            onClientModToggle(modName)
-          }
-          note={note}
+          onChange={() => onClientModToggle(modName)}
         >
           Enable {modName}
         </SwitchItem>


### PR DESCRIPTION
# Hello!
This PR removes the option to enable or disable the shelter client mod in the `Plugins` tab in settings. 

*Closes #98*

## Preview
<img width="1592" height="907" alt="Capture d’écran 2026-05-07 à 23 02 35" src="https://github.com/user-attachments/assets/98538d6f-be26-4ee3-ac81-c3edaffb21dd" />
